### PR TITLE
feat(Batalha): CRUD - Create

### DIFF
--- a/src/main/java/br/com/batalharepg/avanade/repository/PersonagemRepository.java
+++ b/src/main/java/br/com/batalharepg/avanade/repository/PersonagemRepository.java
@@ -2,6 +2,7 @@ package br.com.batalharepg.avanade.repository;
 
 import br.com.batalharepg.avanade.entities.Personagem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +11,7 @@ import java.util.UUID;
 @Repository
 public interface PersonagemRepository extends JpaRepository<Personagem, UUID> {
     Optional<Personagem> findByNome(String nome);
+
+    @Query("SELECT p FROM Personagem p WHERE p.nome IN ('Aboleth', 'Balor', 'Denathor') ORDER BY RANDOM() LIMIT 1")
+    Personagem sorteiaMonstroDefaultParaCombate();
 }

--- a/src/main/java/br/com/batalharepg/avanade/service/BatalhaService.java
+++ b/src/main/java/br/com/batalharepg/avanade/service/BatalhaService.java
@@ -29,10 +29,15 @@ public class BatalhaService {
     public static final String BATALHA_NAO_ENCONTRADA = "Batalha não encontrada";
 
     public BatalhaResponse criarBatalha(CriarBatalhaRequest batalhaRequest) {
+        Personagem defensor;
         Personagem atacante = personagemRepository.findByNome(batalhaRequest.nomeJogadorAtacante())
             .orElseThrow(() -> new NotFoundException("Atacante não encontrado"));
-        Personagem defensor = personagemRepository.findByNome(batalhaRequest.nomeMonstroDefensor())
-            .orElseThrow(() -> new NotFoundException("Defensor não encontrado"));
+        if (batalhaRequest.nomeMonstroDefensor() == null) {
+            defensor = personagemRepository.sorteiaMonstroDefaultParaCombate();
+        } else {
+            defensor = personagemRepository.findByNome(batalhaRequest.nomeMonstroDefensor())
+                .orElseThrow(() -> new NotFoundException("Defensor não encontrado"));
+        }
         if (!defensor.getTipoPersonagem().equals(TipoPersonagem.MONSTRO)) {
             throw new TipoPersonagemDefensorIncorretoException("Defensor não é um monstro");
         }


### PR DESCRIPTION
Implementa logica para criacao de batalha sem defensor definido, escolhendo um dos monstros defaults para ser o defensor